### PR TITLE
kakao app key 관리 방식 변경

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -1,3 +1,5 @@
+import org.jetbrains.kotlin.konan.properties.Properties
+
 plugins {
     alias(libs.plugins.android.application)
     alias(libs.plugins.kotlin.android)
@@ -22,6 +24,19 @@ android {
         vectorDrawables {
             useSupportLibrary = true
         }
+
+        // local.properties load
+        val localProperties = Properties()
+        val localPropertiesFile = rootProject.file("local.properties")
+
+        if (localPropertiesFile.exists()) {
+            localProperties.load(localPropertiesFile.inputStream())
+        }
+
+        val kakaoKey = localProperties.getProperty("kakao_native_app_key") ?: ""
+        // manifest key value 등록
+        manifestPlaceholders["KAKAO_NATIVE_APP_KEY"] = kakaoKey
+        buildConfigField("String", "KAKAO_NATIVE_APP_KEY", "\"$kakaoKey\"")
     }
 
     buildTypes {
@@ -33,16 +48,21 @@ android {
             )
         }
     }
+
     compileOptions {
         sourceCompatibility = JavaVersion.VERSION_1_8
         targetCompatibility = JavaVersion.VERSION_1_8
     }
+
     kotlinOptions {
         jvmTarget = "1.8"
     }
+
     buildFeatures {
         compose = true
+        buildConfig = true
     }
+
     composeOptions {
         kotlinCompilerExtensionVersion = "1.5.1"
     }

--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -30,7 +30,7 @@
 
                 <data
                     android:host="oauth"
-                    android:scheme="kakaod660673b614325c5987061bfd74d5393" />
+                    android:scheme="kakaod${KAKAO_NATIVE_APP_KEY}" />
             </intent-filter>
         </activity>
 
@@ -48,7 +48,7 @@
 
         <service
             android:name="com.asap.data.remote.firebase.MyFirebaseMessageService"
-            android:exported="true">
+            android:exported="false">
             <intent-filter>
                 <action android:name="com.google.firebase.MESSAGING_EVENT" />
             </intent-filter>

--- a/app/src/main/java/com/asap/aljyo/components/Application.kt
+++ b/app/src/main/java/com/asap/aljyo/components/Application.kt
@@ -1,8 +1,7 @@
 package com.asap.aljyo.components
 
 import android.app.Application
-import androidx.compose.ui.res.stringResource
-import com.asap.aljyo.R
+import com.asap.aljyo.BuildConfig
 import com.kakao.sdk.common.KakaoSdk
 import dagger.hilt.android.HiltAndroidApp
 
@@ -12,6 +11,6 @@ class AljyoApplication : Application() {
         super.onCreate()
 
         // initial kakao SDK
-        KakaoSdk.init(this, getString(R.string.kakao_native_app_key))
+        KakaoSdk.init(this, BuildConfig.KAKAO_NATIVE_APP_KEY)
     }
 }


### PR DESCRIPTION
- local.properties 파일로 이동하여 외부 노출 제한
- manifestPlaceholder를 통한 값 등록
- buildConfigField를 통해 BuildConfig.KAKAO_NATIVE_APP_KEY를 통해 코틀린 코드에서 참조 가능하도록 수정